### PR TITLE
added conditional filter (skips if contains words) Sent Tweet to DM

### DIFF
--- a/src/DotNetTwitterBot/Function.cs
+++ b/src/DotNetTwitterBot/Function.cs
@@ -50,7 +50,7 @@ namespace DotNetTwitterBot
                     if (filterTerms.Any(d => tweet.Text.Contains(d)))
                     {
                         //This sends the questionable tweet to the DM's of the me.User
-                        Message.PublishMessage($"Questionable Tweet : {tweet.Url}", User.GetUserFromScreenName($"{me.ScreenName}").Id);
+                        Message.PublishMessageAsync($"Questionable Tweet : {tweet.Url}", User.GetUserFromScreenName($"{me.ScreenName}").Id);
                         continue;
                     }
                     // Exclude tweets that are from automated GitHub issues, except dotnetissues because

--- a/src/DotNetTwitterBot/Function.cs
+++ b/src/DotNetTwitterBot/Function.cs
@@ -50,7 +50,7 @@ namespace DotNetTwitterBot
                     if (filterTerms.Any(d => tweet.Text.Contains(d)))
                     {
                         //This sends the questionable tweet to the DM's of the me.User
-                        Message.PublishMessageAsync($"Questionable Tweet : {tweet.Url}", User.GetUserFromScreenName($"{me.ScreenName}").Id);
+                        await Message.PublishMessageAsync($"Questionable Tweet : {tweet.Url}", User.GetUserFromScreenName($"{me.ScreenName}").Id);
                         continue;
                     }
                     // Exclude tweets that are from automated GitHub issues, except dotnetissues because

--- a/src/DotNetTwitterBot/Function.cs
+++ b/src/DotNetTwitterBot/Function.cs
@@ -21,11 +21,11 @@ namespace DotNetTwitterBot
 
             Auth.SetUserCredentials(creds.ConsumerKey, creds.ConsumerSecret, creds.AccessToken, creds.AccessSecret);
 
-            var searchTerms = new[] { $"\".NET Framework\"", "\".NET Core\"", "\".NET 5\"", "dotnet", "dotnetcore", "_dotnetbot_" };
+            var searchTerms = new[] { "\".NET Framework\"", "\".NET Core\"", "\".NET 5\"", "dotnet", "dotnetcore", "_dotnetbot_" };
 
             var searchSince = DateTime.UtcNow.Subtract(TimeSpan.FromMinutes(10));
 
-            var filterTerms = new[] { $@"domain", $@"registration", $@"domainregistration" };
+            var filterTerms = new[] { "domain", "registration", "domainregistration" };
 
             var me = User.GetAuthenticatedUser();
 

--- a/src/DotNetTwitterBot/Function.cs
+++ b/src/DotNetTwitterBot/Function.cs
@@ -49,7 +49,7 @@ namespace DotNetTwitterBot
                     // Exclude tweets that contain excluded words.
                     if (filterTerms.Any(d => tweet.Text.Contains(d)))
                     {
-                        //This sends the questionable tweet to the DM's of the me.User (not sure this will work, update the username for review)
+                        //This sends the questionable tweet to the DM's of the me.User
                         Message.PublishMessage($"Questionable Tweet : {tweet.Url}", User.GetUserFromScreenName($"{me.ScreenName}").Id);
                         continue;
                     }


### PR DESCRIPTION
I added an additional filter list (words that if found should mark the tweet as not retweetable). 
just in case it should send the tweets to the DM's for review.

Summary of the changes

- Added string "Filter"
- tested content of the tweet for the filter words.

Fixes #5 
