### PR TITLE
Optimize function to reduce Twitter API calls

### DIFF
--- a/src/DotNetTwitterBot/Function.cs
+++ b/src/DotNetTwitterBot/Function.cs
@@ -33,13 +33,13 @@ namespace DotNetTwitterBot
             var me = User.GetAuthenticatedUser();
 
             await Task.WhenAll(
-                SearchAndRetweetTweets(string.Join(' ', SearchTerms), searchSince, me),
-                SearchAndRetweetTweets(string.Join(' ', SearchTracks), searchSince, me));
+                SearchAndRetweetTweets(SearchTerms, searchSince, me),
+                SearchAndRetweetTweets(SearchTracks, searchSince, me));
 
-            static async Task SearchAndRetweetTweets(string query, DateTime searchSince, IAuthenticatedUser me)
+            static async Task SearchAndRetweetTweets(string[] terms, DateTime searchSince, IAuthenticatedUser me)
             {
                 var filterTerms = new[] { "domain", "registration", "domainregistration", "@paul_dotnet" };
-
+                var query = string.Join(' ', terms);
                 var param = new SearchTweetsParameters(query)
                 {
                     Since = searchSince,
@@ -51,7 +51,7 @@ namespace DotNetTwitterBot
                 foreach (var tweet in tweets)
                 {
                     // Exclude tweets that don't specifically mention search terms
-                    if (!query.Split(" ").Any(term => tweet.Text.Contains(term, StringComparison.OrdinalIgnoreCase)))
+                    if (!terms.Any(term => tweet.Text.Contains(term, StringComparison.OrdinalIgnoreCase)))
                         continue;
 
                     // Exclude tweets that contain excluded words.

--- a/src/DotNetTwitterBot/Function.cs
+++ b/src/DotNetTwitterBot/Function.cs
@@ -39,7 +39,7 @@ namespace DotNetTwitterBot
             static async Task SearchAndRetweetTweets(string[] terms, DateTime searchSince, IAuthenticatedUser me)
             {
                 var filterTerms = new[] { "domain", "registration", "domainregistration", "@paul_dotnet" };
-                var query = string.Join(' ', terms);
+                var query = string.Join(" OR ", terms);
                 var param = new SearchTweetsParameters(query)
                 {
                     Since = searchSince,

--- a/src/DotNetTwitterBot/Function.cs
+++ b/src/DotNetTwitterBot/Function.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Amazon.Lambda.Core;
@@ -11,39 +10,48 @@ namespace DotNetTwitterBot
 {
     public class Functions
     {
-        public Functions()
+        static readonly string[] SearchTerms = new[]
         {
-        }
+            "\".NET Framework\"",
+            "\".NET Core\"",
+            "\".NET 5\""
+        };
+
+        static readonly string[] SearchTracks = new[]
+        {
+            "#dotnet",
+            "#dotnetcore",
+            "@_dotnetbot_"
+        };
 
         public async Task Retweet(ILambdaContext context)
         {
             var creds = await SecretHelper.GetSecretAsync();
-
             Auth.SetUserCredentials(creds.ConsumerKey, creds.ConsumerSecret, creds.AccessToken, creds.AccessSecret);
-
-            var searchTerms = new[] { "\".NET Framework\"", "\".NET Core\"", "\".NET 5\"", "dotnet", "dotnetcore", "_dotnetbot_" };
-
+            
             var searchSince = DateTime.UtcNow.Subtract(TimeSpan.FromMinutes(35));
-
-            var filterTerms = new[] { "domain", "registration", "domainregistration", "@paul_dotnet" };
-
             var me = User.GetAuthenticatedUser();
 
-            foreach (var term in searchTerms)
+            await Task.WhenAll(
+                SearchAndRetweetTweets(string.Join(' ', SearchTerms), searchSince, me),
+                SearchAndRetweetTweets(string.Join(' ', SearchTracks), searchSince, me));
+
+            static async Task SearchAndRetweetTweets(string query, DateTime searchSince, IAuthenticatedUser me)
             {
-                var param = new SearchTweetsParameters(term)
+                var filterTerms = new[] { "domain", "registration", "domainregistration", "@paul_dotnet" };
+
+                var param = new SearchTweetsParameters(query)
                 {
                     Since = searchSince,
                     TweetSearchType = TweetSearchType.OriginalTweetsOnly,
                     Filters = TweetSearchFilters.Safe
                 };
 
-                var tweets = Search.SearchTweets(param);
-
+                var tweets = await SearchAsync.SearchTweets(param);
                 foreach (var tweet in tweets)
                 {
                     // Exclude tweets that don't specifically mention search terms
-                    if (!tweet.Text.Contains(term, StringComparison.OrdinalIgnoreCase))
+                    if (!query.Split(" ").Any(term => tweet.Text.Contains(term, StringComparison.OrdinalIgnoreCase)))
                         continue;
 
                     // Exclude tweets that contain excluded words.
@@ -59,8 +67,7 @@ namespace DotNetTwitterBot
                     var retweetTask = tweet.PublishRetweetAsync();
                     var followTask = me.FollowUserAsync(tweet.CreatedBy.Id);
 
-                    await retweetTask;
-                    await followTask;
+                    await Task.WhenAll(retweetTask, followTask);
                 }
             }
         }


### PR DESCRIPTION
Let me start by saying, this is an awesome repo - very well done! I love the bot, and appreciate the RT's from it I see. For that I thank you. I wanted to collaborate a bit and have a proposal for a few optimizations. I hope you like them. 👍 

Summary of the changes

- Optimize function to reduce Twitter API calls, reduced to two calls instead of six
  - Searches can be done with space-delimited `q=` queries (API is similar to their site search):
    - https://twitter.com/search?q=%23dotnet%20OR%20%23dotnetcore%20OR%20%40_dotnetbot_&src=typed_query
    - https://twitter.com/search?q=%22.NET%20Framework%22%20OR%20%22.NET%20Core%22%20OR%20%22.NET%205%22&src=typed_query
- Use parallel task-based invocations where possible, i.e.; `Task.WhenAll`
- Remove nested `foreach`
- Remove un-used `using` statements
- Move search terms to class-scope as fields
- Split search terms
  - One group is for literals
  - The other group for tracks, (aka, hashtags and handles)
- Use `static` local function for encapsulating iterative logic
- Remove redundant `.ctor`

